### PR TITLE
fix: add protocol to endpoints

### DIFF
--- a/docs/networks/starknet.mdx
+++ b/docs/networks/starknet.mdx
@@ -11,15 +11,15 @@ Apibara provides data streams for all StarkNet networks:
 
 **StarkNet Mainnet**
 
- - endpoint: `mainnet.starknet.a5a.ch:443`
+ - endpoint: `https://mainnet.starknet.a5a.ch`
 
 **StarkNet Görli Testnet**
 
- - endpoint: `goerli.starknet.a5a.ch:443`
+ - endpoint: `https://goerli.starknet.a5a.ch`
 
 **StarkNet Görli 2 Testnet**
 
- - endpoint: `goerli-2.starknet.a5a.ch:443`
+ - endpoint: `https://goerli-2.starknet.a5a.ch`
 
 
 ## Data and filters


### PR DESCRIPTION
When copy-pasting endpoint from documentation I get the following error:
```
Error:
   0: transport error
   1: error trying to connect: invalid URL, scheme is missing
   2: invalid URL, scheme is missing
```
This is due to missing protocol, I suggest updating docs with protocol and ditching the port number.